### PR TITLE
ServiceContext中增加Service-Context-User

### DIFF
--- a/src/main/java/org/nofdev/servicefacade/ServiceContext.java
+++ b/src/main/java/org/nofdev/servicefacade/ServiceContext.java
@@ -9,6 +9,7 @@ public class ServiceContext extends HashMap<String, Object> {
 
     public static final String PREFIX = "Service-Context";
     public static final String CALLID = "Service-Context-CallId";
+    public static final String USER = "Service-Context-User";
 
     public void setCallId(CallId callId) {
         put(CALLID, callId);
@@ -17,6 +18,19 @@ public class ServiceContext extends HashMap<String, Object> {
     public CallId getCallId() {
         if (get(CALLID) != null) {
             return (CallId) get(CALLID);
+        } else {
+            return null;
+        }
+    }
+
+
+    public void setUser(User user) {
+        put(USER, user);
+    }
+
+    public User getUser() {
+        if (get(USER) != null) {
+            return (User) get(USER);
         } else {
             return null;
         }

--- a/src/main/java/org/nofdev/servicefacade/User.java
+++ b/src/main/java/org/nofdev/servicefacade/User.java
@@ -1,0 +1,16 @@
+package org.nofdev.servicefacade;
+
+/**
+ * Created by Liutengfei on 2016/9/23 0023.
+ */
+public class User {
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}


### PR DESCRIPTION
ServiceContext中增加Service-Context-User，
因为ServiceContext与ThreadLocal绑定，这样就可以通过
`ServiceContextHolder.getServiceContext().getUser()`获取当前登录用户信息
